### PR TITLE
app.jsonに env キーを追加して、ユーザーがフォームにトークンを入力するだけで稼働できるようにする

### DIFF
--- a/app.json
+++ b/app.json
@@ -20,7 +20,7 @@
     },
     "DISCORD_BOT_PREFIX": {
             "description": "ボットのプレフィックスを入力します。",
-            "value": "🦑"
+            "required": "false"
     }
   }
 }

--- a/app.json
+++ b/app.json
@@ -16,7 +16,7 @@
   ],
   "env": {
     "DISCORD_BOT_TOKEN": {
-            "description": "ボットのトークンを入力します。,
+            "description": "ボットのトークンを入力します。",
     },
     "DISCORD_BOT_PREFIX": {
             "description": "ボットのプレフィックスを入力します。",

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "distalk",
   "description": "Discord TTS on heroku",
-  "repository": "https://github.com/coolwind0202/distalk",
+  "repository": "https://github.com/distalkbot/distalk",
   "keywords": ["python", "discord", "bot"],
   "buildpacks": [
     {

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "name": "distalk",
   "description": "Discord TTS on heroku",
-  "repository": "https://github.com/distalkbot/distalk",
+  "repository": "https://github.com/coolwind0202/distalk",
   "keywords": ["python", "discord", "bot"],
   "buildpacks": [
     {
@@ -13,5 +13,14 @@
     {
       "url": "https://github.com/Crazycatz00/heroku-buildpack-libopus.git"
     }
-  ]
+  ],
+  "env": {
+    "DISCORD_BOT_TOKEN": {
+            "description": "ボットのトークンを入力します。,
+    },
+    "DISCORD_BOT_PREFIX": {
+            "description": "ボットのプレフィックスを入力します。",
+            "value": "🦑"
+    }
+  }
 }

--- a/app.json
+++ b/app.json
@@ -20,7 +20,7 @@
     },
     "DISCORD_BOT_PREFIX": {
             "description": "ボットのプレフィックスを入力します。",
-            "required": "false"
+            "required": false
     }
   }
 }

--- a/app.json
+++ b/app.json
@@ -16,7 +16,7 @@
   ],
   "env": {
     "DISCORD_BOT_TOKEN": {
-            "description": "ボットのトークンを入力します。",
+            "description": "ボットのトークンを入力します。"
     },
     "DISCORD_BOT_PREFIX": {
             "description": "ボットのプレフィックスを入力します。",


### PR DESCRIPTION
[Qiitaの記事](https://qiita.com/akira_splatoon/items/f63978411786c8574556)　を見て、HerokuボタンだけでBotをデプロイできるのは便利だと思いました。

BOTトークンの環境変数も、デプロイ時に入力できるようにすれば簡単になるのではないかと思いました。

Config Varsフォームにトークンを入力して Deploy app すると環境変数がそのまま反映されます。

![image](https://user-images.githubusercontent.com/51913600/122629681-c5dd9780-d0f9-11eb-9f2c-805a7e21171e.png)
